### PR TITLE
Remove the test images when cleaning

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -13,3 +13,5 @@ test: $(OBJECTS)
 
 clean:
 	rm $(NAME)
+	rm "test.bmp"
+	rm "test2.bmp"


### PR DESCRIPTION
When the clean cmd gets called it now deletes the images in addition to the binary.