### PR TITLE
Update libbmp.c

### DIFF
--- a/libbmp.c
+++ b/libbmp.c
@@ -10,7 +10,7 @@
 void bmp_header_init_df (bmp_header *header, const int width, const int height)
 {
 	/* Init a bmp_header with the default values. */
-	header->bfSize = (sizeof (bmp_pixel) * width * abs (height)) + (sizeof (unsigned char) * BMP_GET_PADDING (width) * abs (height));
+	header->bfSize = (sizeof (bmp_pixel) * width + sizeof (unsigned char) * BMP_GET_PADDING (width)) * abs (height);
 	header->bfReserved = 0;
 	header->bfOffBits = 54;
 	header->biSize = 40;


### PR DESCRIPTION
Simplify the calculation of bfSize at the bmp_header_init_df function.