### PR TITLE
Unnecessary header

### DIFF
--- a/libbmp.c
+++ b/libbmp.c
@@ -3,7 +3,6 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include "libbmp.h"
 
 // BMP_HEADER


### PR DESCRIPTION
Don't include the string header if it is not used. 