### PR TITLE
Remove the call to 'abs' since unsigned values cannot be negative

### DIFF
--- a/libbmp.c
+++ b/libbmp.c
@@ -161,7 +161,7 @@ bmp_img_write (const bmp_img *img,
 	for (size_t y = 0; y < h; y++)
 	{
 		// Write a whole row of pixels to the file:
-		fwrite (img->img_pixels[abs (offset - y)], sizeof (bmp_pixel), img->img_header.biWidth, img_file);
+		fwrite (img->img_pixels[offset - y], sizeof (bmp_pixel), img->img_header.biWidth, img_file);
 		
 		// Write the padding for the row!
 		fwrite (padding, sizeof (unsigned char), BMP_GET_PADDING (img->img_header.biWidth), img_file);
@@ -207,7 +207,7 @@ bmp_img_read (bmp_img    *img,
 	for (size_t y = 0; y < h; y++)
 	{
 		// Read a whole row of pixels from the file:
-		if (fread (img->img_pixels[abs (offset - y)], sizeof (bmp_pixel), items, img_file) != items)
+		if (fread (img->img_pixels[offset - y], sizeof (bmp_pixel), items, img_file) != items)
 		{
 			fclose (img_file);
 			return BMP_ERROR;


### PR DESCRIPTION
The C11 standard states that for unsigned integers modulo wrapping is
the defined behavior and the term overflow never applies: "a
computation involving unsigned operands can never overflow."

Fixes warnings (clang):
```
ibbmp.c
../../home/juergen/shared/low-level-programming/sepia_filter/libbmp/libbmp.c:164:27: warning: taking the absolute value of unsigned type 'unsigned long' has no effect [-Wabsolute-value]
                fwrite (img->img_pixels[abs (offset - y)], sizeof (bmp_pixel), img->img_header.biWidth, img_file);
                                        ^
../../home/juergen/shared/low-level-programming/sepia_filter/libbmp/libbmp.c:164:27: note: remove the call to 'abs' since unsigned values cannot be negative
                fwrite (img->img_pixels[abs (offset - y)], sizeof (bmp_pixel), img->img_header.biWidth, img_file);
                                        ^~~
../../home/juergen/shared/low-level-programming/sepia_filter/libbmp/libbmp.c:210:30: warning: taking the absolute value of unsigned type 'unsigned long' has no effect [-Wabsolute-value]
                if (fread (img->img_pixels[abs (offset - y)], sizeof (bmp_pixel), items, img_file) != items)
                                           ^
../../home/juergen/shared/low-level-programming/sepia_filter/libbmp/libbmp.c:210:30: note: remove the call to 'abs' since unsigned values cannot be negative
                if (fread (img->img_pixels[abs (offset - y)], sizeof (bmp_pixel), items, img_file) != items)
                                           ^~~
2 warnings generated.
```