### PR TITLE
#include <fstream> in c++ header, required by the C++ library

### DIFF
--- a/CPP/libbmp.h
+++ b/CPP/libbmp.h
@@ -1,6 +1,7 @@
 #ifndef __LIBBMP_H__
 #define __LIBBMP_H__
 
+#include <fstream>
 #include <vector>
 
 #define BMP_MAGIC 19778


### PR DESCRIPTION
Hi,  I included also <fstream> in the C++ header, or otherwise a program not including it before libbmp.h doesn't compile (you're using ofstream and istream in the header).